### PR TITLE
Force SteamID64 to string so VyHub accepts it

### DIFF
--- a/lua/vyhub/server/sv_ply.lua
+++ b/lua/vyhub/server/sv_ply.lua
@@ -12,7 +12,7 @@ local meta_ply = FindMetaTable("Player")
 function VyHub.Player:initialize(ply, retry)
     if not IsValid(ply) then return end
 
-    local steamid = ply:SteamID64()
+    local steamid = tostring( ply:SteamID64() )
 
     VyHub:msg(f("Initializing user %s, %s", ply:Nick(), steamid))
 


### PR DESCRIPTION
Force SteamID64 to string when posting to VyHub API